### PR TITLE
Feature/save passages

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -5,6 +5,7 @@ import Home from '../Home/Home';
 import Genre from '../Genre/Genre';
 import Play from '../Play/Play';
 import SonnetsMenu from '../SonnetsMenu/SonnetsMenu'
+import SavedPassages from '../SavedPassages/SavedPassages'
 
 const App = () => {
 
@@ -13,13 +14,14 @@ const App = () => {
       <h1>BARD BUDDY</h1>
       <nav>
         <NavLink to='/'>HOME</NavLink>
-        <NavLink to='/'>SAVED PASSAGES</NavLink>
+        <NavLink to='/saved-passages'>SAVED PASSAGES</NavLink>
       </nav>
       <Switch>
         <Route exact path='/' component={Home}/>
         <Route exact path={['/tragedies', '/comedies', '/histories']} render={({ match }) => <Genre genre={match.path} /> } />
         <Route path={['/tragedies/:play', '/comedies/:play', '/histories/:play']} render={({ match }) => <Play play={match.params.play} /> } />
         <Route path='/sonnets' render={() => <SonnetsMenu /> } />
+        <Route path='/saved-passages' render={() => <SavedPassages /> } />
         <Route path='*' />
       </Switch>
     </main>

--- a/src/components/CharacterList/CharacterList.js
+++ b/src/components/CharacterList/CharacterList.js
@@ -9,7 +9,7 @@ export default class CharacterList extends Component {
     }
   }
 
-  compileCharacterList() {
+  compileCharacterList = () => {
     return this.state.characters.map(character => {
       return (
         <p key={character.charid}><strong>{character.charname}</strong>{character.descrip.length ? `- ${character.descrip}` : null}</p>
@@ -17,7 +17,7 @@ export default class CharacterList extends Component {
     })
   }
 
-  render() {
+  render = () => {
     if(!this.state.isExpanded) {
       return (
         <div>

--- a/src/components/Play/Play.js
+++ b/src/components/Play/Play.js
@@ -36,7 +36,7 @@ export default class Play extends Component {
           {directory.indexOf(act) ? <h1>Act {numToRoms(directory.indexOf(act), false)}</h1> : <h1>Prologue</h1>}
           {act.map(scene => {
             return (
-              <PlayText act={directory.indexOf(act)} scene={scene.scene} fullText={this.state.text} characters={this.state.characters} key={`${this.state.play}-act${directory.indexOf(act)}-scene${scene.scene}`} />
+              <PlayText play={this.state.play} act={directory.indexOf(act)} scene={scene.scene} fullText={this.state.text} characters={this.state.characters} key={`${this.state.play}-act${directory.indexOf(act)}-scene${scene.scene}`} />
             )
           })}
         </div>

--- a/src/components/Play/Play.js
+++ b/src/components/Play/Play.js
@@ -36,7 +36,7 @@ export default class Play extends Component {
           {directory.indexOf(act) ? <h1>Act {numToRoms(directory.indexOf(act), false)}</h1> : <h1>Prologue</h1>}
           {act.map(scene => {
             return (
-              <PlayText play={this.state.play} act={directory.indexOf(act)} scene={scene.scene} fullText={this.state.text} characters={this.state.characters} key={`${this.state.play}-act${directory.indexOf(act)}-scene${scene.scene}`} />
+              <PlayText play={this.state.play} act={directory.indexOf(act)} scene={scene.scene} fullText={this.state.text} characters={this.state.characters} fullTitle={this.state.fullTitle} key={`${this.state.play}-act${directory.indexOf(act)}-scene${scene.scene}`} />
             )
           })}
         </div>

--- a/src/components/Play/Play.js
+++ b/src/components/Play/Play.js
@@ -16,12 +16,12 @@ export default class Play extends Component {
     }
   }
 
-  componentDidMount() {
+  componentDidMount = () => {
     fetchPlayData(this.state.play)
     .then(data => this.setState({ characters: data.allCharacters, chapters: data.allChapters, fullTitle: data.fullTitle, text: data.fullText }))
   }
 
-  compileDirectory() {
+  compileDirectory = () => {
     const directory = []
     this.state.chapters.map(chapter => {
       if (directory[chapter.act]) {
@@ -44,7 +44,7 @@ export default class Play extends Component {
     })
   }
 
-  render() {
+  render = () => {
     return (
       <div className="play-body">
         <h1>{this.state.fullTitle}</h1>

--- a/src/components/PlayLine/PlayLine.css
+++ b/src/components/PlayLine/PlayLine.css
@@ -1,0 +1,3 @@
+.linenum {
+  width: 50px;
+}

--- a/src/components/PlayLine/PlayLine.css
+++ b/src/components/PlayLine/PlayLine.css
@@ -1,3 +1,12 @@
 .linenum {
   width: 50px;
 }
+
+.line:hover,
+.saved-line {
+  background-color: aqua;
+}
+
+.saved-line:hover {
+  background-color: red;
+}

--- a/src/components/PlayLine/PlayLine.js
+++ b/src/components/PlayLine/PlayLine.js
@@ -14,7 +14,7 @@ export default class PlayLine extends Component {
   }
 
   componentDidMount() {
-    if (localStorage.getItem(`${this.state.play}-${this.state.lineNum}`)) {
+    if (localStorage.getItem('bard-buddy') && JSON.parse(localStorage.getItem('bard-buddy')).find(item => item.text === this.state.text)) {
       this.setState({ isSaved: true })
     } else {
       this.setState({ isSaved: false })
@@ -22,13 +22,23 @@ export default class PlayLine extends Component {
   }
 
   delete = () => {
-    localStorage.removeItem(`${this.state.play}-${this.state.lineNum}`)
+    let storage = JSON.parse(localStorage.getItem('bard-buddy'))
+    console.log(storage.indexOf(this.state))
+    storage.splice(storage.indexOf(storage.find(item => item.text === this.state.text)), 1)
+    localStorage.setItem('bard-buddy', JSON.stringify(storage))
     this.setState({ isSaved: false })
   }
 
   save = () => {
-    localStorage.setItem(`${this.state.play}-${this.state.lineNum}`, JSON.stringify(this.state))
-    this.setState({ isSaved: true })
+    if (localStorage.getItem('bard-buddy')) {
+      let storage = JSON.parse(localStorage.getItem('bard-buddy'))
+      storage.push(this.state)
+      localStorage.setItem('bard-buddy', JSON.stringify(storage))
+      this.setState({ isSaved: true })
+    } else {
+      localStorage.setItem('bard-buddy', JSON.stringify([this.state]))
+      this.setState({ isSaved: true })
+    }
   }
 
   render() {

--- a/src/components/PlayLine/PlayLine.js
+++ b/src/components/PlayLine/PlayLine.js
@@ -1,0 +1,36 @@
+import React, { Component } from 'react'
+import './PlayLine.css'
+
+export default class PlayLine extends Component {
+  constructor({ text, lineNum, character }) {
+    super()
+    this.state = {
+      text: text,
+      lineNum: lineNum,
+      character: character
+    }
+  }
+
+  render() {
+    if(this.state.character === 'xxx') {
+      return (
+        <table>
+          <tr>
+            <td className="linenum">{this.state.lineNum % 5 === 0 ? this.state.lineNum : " "}</td>
+            <td><i>{this.state.text.replace('\\n', '')}</i></td>
+          </tr>
+        </table>
+      )
+    } else {
+      return (
+        <table>
+          <tr>
+            <td className="linenum">{this.state.lineNum % 5 === 0 ? this.state.lineNum : " "}</td>
+            <td>{this.state.text.replace('\\n', '')}</td>
+          </tr>
+        </table>
+      )
+    }
+  }
+
+}

--- a/src/components/PlayLine/PlayLine.js
+++ b/src/components/PlayLine/PlayLine.js
@@ -2,14 +2,17 @@ import React, { Component } from 'react'
 import './PlayLine.css'
 
 export default class PlayLine extends Component {
-  constructor({ play, text, lineNum, character }) {
+  constructor({ play, text, lineNum, character, act, scene, fullTitle }) {
     super()
     this.state = {
       play: play,
       text: text,
       lineNum: lineNum,
       character: character,
-      isSaved: null
+      isSaved: null,
+      act: act,
+      scene: scene,
+      fullTitle: fullTitle
     }
   }
 
@@ -23,7 +26,6 @@ export default class PlayLine extends Component {
 
   delete = () => {
     let storage = JSON.parse(localStorage.getItem('bard-buddy'))
-    console.log(storage.indexOf(this.state))
     storage.splice(storage.indexOf(storage.find(item => item.text === this.state.text)), 1)
     localStorage.setItem('bard-buddy', JSON.stringify(storage))
     this.setState({ isSaved: false })
@@ -31,13 +33,13 @@ export default class PlayLine extends Component {
 
   save = () => {
     if (localStorage.getItem('bard-buddy')) {
+      this.setState({ isSaved: true })
       let storage = JSON.parse(localStorage.getItem('bard-buddy'))
       storage.push(this.state)
       localStorage.setItem('bard-buddy', JSON.stringify(storage))
-      this.setState({ isSaved: true })
     } else {
-      localStorage.setItem('bard-buddy', JSON.stringify([this.state]))
       this.setState({ isSaved: true })
+      localStorage.setItem('bard-buddy', JSON.stringify([this.state]))
     }
   }
 

--- a/src/components/PlayLine/PlayLine.js
+++ b/src/components/PlayLine/PlayLine.js
@@ -2,32 +2,56 @@ import React, { Component } from 'react'
 import './PlayLine.css'
 
 export default class PlayLine extends Component {
-  constructor({ text, lineNum, character }) {
+  constructor({ play, text, lineNum, character }) {
     super()
     this.state = {
+      play: play,
       text: text,
       lineNum: lineNum,
-      character: character
+      character: character,
+      isSaved: null
     }
   }
 
+  componentDidMount() {
+    if (localStorage.getItem(`${this.state.play}-${this.state.lineNum}`)) {
+      this.setState({ isSaved: true })
+    } else {
+      this.setState({ isSaved: false })
+    }
+  }
+
+  delete = () => {
+    localStorage.removeItem(`${this.state.play}-${this.state.lineNum}`)
+    this.setState({ isSaved: false })
+  }
+
+  save = () => {
+    localStorage.setItem(`${this.state.play}-${this.state.lineNum}`, JSON.stringify(this.state))
+    this.setState({ isSaved: true })
+  }
+
   render() {
-    if(this.state.character === 'xxx') {
+    if (this.state.isSaved) {
       return (
-        <table>
-          <tr>
-            <td className="linenum">{this.state.lineNum % 5 === 0 ? this.state.lineNum : " "}</td>
-            <td><i>{this.state.text.replace('\\n', '')}</i></td>
-          </tr>
+        <table className='saved-line'>
+          <tbody>
+            <tr>
+              <td className="linenum">{this.state.lineNum % 5 === 0 ? this.state.lineNum : " "}</td>
+              <td onClick={() => this.delete()}>{this.state.text.replace('\\n', '')}</td>
+            </tr>
+          </tbody>
         </table>
       )
     } else {
       return (
-        <table>
-          <tr>
-            <td className="linenum">{this.state.lineNum % 5 === 0 ? this.state.lineNum : " "}</td>
-            <td>{this.state.text.replace('\\n', '')}</td>
-          </tr>
+        <table className='line'>
+          <tbody>
+            <tr>
+              <td className="linenum">{this.state.lineNum % 5 === 0 ? this.state.lineNum : " "}</td>
+              <td onClick={() => this.save()}>{this.state.text.replace('\\n', '')}</td>
+            </tr>
+          </tbody>
         </table>
       )
     }

--- a/src/components/PlayText/PlayText.css
+++ b/src/components/PlayText/PlayText.css
@@ -1,0 +1,3 @@
+.character {
+  text-indent: 50px;
+}

--- a/src/components/PlayText/PlayText.js
+++ b/src/components/PlayText/PlayText.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react'
 import { numToRoms } from '../../helper-functions'
+import PlayLine from '../PlayLine/PlayLine'
+import './PlayText.css'
 
 export default class PlayText extends Component {
   constructor({ act, scene, fullText, characters }) {
@@ -15,15 +17,12 @@ export default class PlayText extends Component {
 
   grafCompiler = () => {
     return this.state.text.map(graf => {
+      let counter = graf.paragraphnum
       return (
         <div key={graf.paragraphID}>
-          {graf.charid === 'xxx' ? <p></p> : <p><strong>{this.state.characters.find(character => character.charid === graf.charid).charname.toUpperCase()}</strong></p>}
+          {graf.charid === 'xxx' ? <p></p> : <p className='character'><strong>{this.state.characters.find(character => character.charid === graf.charid).charname.toUpperCase()}</strong></p>}
           {graf.plaintext.split('\\n[p]').map(line => {
-            if (graf.charid === 'xxx') {
-              return <i key={`${graf.paragraphID}-${graf.plaintext.split('\\n[p]').indexOf(line)}`}>{line.replace('\\n', '')}</i>
-            } else {
-              return <p key={`${graf.paragraphID}-${graf.plaintext.split('\\n[p]').indexOf(line)}`}>{line.replace('\\n', '')}</p>
-            }    
+            return <PlayLine text={line} lineNum={counter++} character={graf.charid} />
           })}
         </div>
       )

--- a/src/components/PlayText/PlayText.js
+++ b/src/components/PlayText/PlayText.js
@@ -13,7 +13,7 @@ export default class PlayText extends Component {
     }
   }
 
-  grafCompiler() {
+  grafCompiler = () => {
     return this.state.text.map(graf => {
       return (
         <div key={graf.paragraphID}>
@@ -30,7 +30,7 @@ export default class PlayText extends Component {
     })
   }
 
-  render() {
+  render = () => {
     if(!this.state.isExpanded) {
       return (
         <div>

--- a/src/components/PlayText/PlayText.js
+++ b/src/components/PlayText/PlayText.js
@@ -4,7 +4,7 @@ import PlayLine from '../PlayLine/PlayLine'
 import './PlayText.css'
 
 export default class PlayText extends Component {
-  constructor({ play, act, scene, fullText, characters }) {
+  constructor({ play, act, scene, fullText, characters, fullTitle }) {
     super()
     this.state = {
       isExpanded: false,
@@ -12,7 +12,8 @@ export default class PlayText extends Component {
       act: act,
       scene: scene,
       text: fullText.filter(graf => graf.section === act && graf.chapter === scene),
-      characters: characters
+      characters: characters,
+      fullTitle: fullTitle
     }
   }
 
@@ -23,7 +24,7 @@ export default class PlayText extends Component {
         <div key={graf.paragraphID}>
           {graf.charid === 'xxx' ? <p></p> : <p className='character'><strong>{this.state.characters.find(character => character.charid === graf.charid).charname.toUpperCase()}</strong></p>}
           {graf.plaintext.split('\\n[p]').map(line => {
-            return <PlayLine play={this.state.play} text={line} lineNum={counter++} character={graf.charid} />
+            return <PlayLine play={this.state.play} text={line} lineNum={counter++} character={graf.charid} act={this.state.act} scene={this.state.scene} fullTitle={this.state.fullTitle}/>
           })}
         </div>
       )

--- a/src/components/PlayText/PlayText.js
+++ b/src/components/PlayText/PlayText.js
@@ -4,10 +4,11 @@ import PlayLine from '../PlayLine/PlayLine'
 import './PlayText.css'
 
 export default class PlayText extends Component {
-  constructor({ act, scene, fullText, characters }) {
+  constructor({ play, act, scene, fullText, characters }) {
     super()
     this.state = {
       isExpanded: false,
+      play: play,
       act: act,
       scene: scene,
       text: fullText.filter(graf => graf.section === act && graf.chapter === scene),
@@ -22,7 +23,7 @@ export default class PlayText extends Component {
         <div key={graf.paragraphID}>
           {graf.charid === 'xxx' ? <p></p> : <p className='character'><strong>{this.state.characters.find(character => character.charid === graf.charid).charname.toUpperCase()}</strong></p>}
           {graf.plaintext.split('\\n[p]').map(line => {
-            return <PlayLine text={line} lineNum={counter++} character={graf.charid} />
+            return <PlayLine play={this.state.play} text={line} lineNum={counter++} character={graf.charid} />
           })}
         </div>
       )

--- a/src/components/PoemText/PoemText.js
+++ b/src/components/PoemText/PoemText.js
@@ -10,7 +10,7 @@ export default class PoemText extends Component {
     }
   }
 
-  poemFormatter() {
+  poemFormatter = () => {
     return this.state.poemText.map(stanza => {
       const stanzaArray = stanza.plaintext.split('\\n[p]')
       stanzaArray.push('-')
@@ -24,7 +24,7 @@ export default class PoemText extends Component {
     })
   }
 
-  render() {
+  render = () => {
     if (!this.state.isExpanded) {
       return (
         <div>

--- a/src/components/SavedPassages/SavedPassages.js
+++ b/src/components/SavedPassages/SavedPassages.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PlayLine from '../PlayLine/PlayLine'
 
 export default class SavedPassages extends Component {
   constructor() {
@@ -9,15 +10,37 @@ export default class SavedPassages extends Component {
   }
 
   componentDidMount() {
-    this.setState({ savedPassages: localStorage.getItem('romeojuliet-1') })
+    if (localStorage.getItem('bard-buddy')) {
+      let storage = JSON.parse(localStorage.getItem('bard-buddy'))
+      this.setState({ savedPassages: storage })
+    }
+  }
+
+  compileSavedPassages() {
+    return this.state.savedPassages.map(line => {
+      let play = line.play
+      let text = line.text
+      let lineNum = line.lineNum
+      let character = line.character
+      return <PlayLine play={play} text={text} lineNum={lineNum} character={character} />
+    })
   }
 
   render() {
     console.log(this.state)
-    return (
-      <div>
-        <h2>Your saved passages:</h2>
-      </div>
-    )
+    if (!this.state.savedPassages.length) {
+      return (
+        <div>
+          <h2>You have no saved passages!</h2>
+        </div>
+      )
+    } else {
+      return (
+        <div>
+          <h2>Your saved passages:</h2>
+          {this.compileSavedPassages()}
+        </div>
+      )
+    }
   }
 }

--- a/src/components/SavedPassages/SavedPassages.js
+++ b/src/components/SavedPassages/SavedPassages.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react'
+
+export default class SavedPassages extends Component {
+  constructor() {
+    super()
+    this.state = {
+      savedPassages: []
+    }
+  }
+
+  componentDidMount() {
+    this.setState({ savedPassages: localStorage.getItem('romeojuliet-1') })
+  }
+
+  render() {
+    console.log(this.state)
+    return (
+      <div>
+        <h2>Your saved passages:</h2>
+      </div>
+    )
+  }
+}

--- a/src/components/SavedPassages/SavedPassages.js
+++ b/src/components/SavedPassages/SavedPassages.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PlayLine from '../PlayLine/PlayLine'
+import { numToRoms } from '../../helper-functions'
 
 export default class SavedPassages extends Component {
   constructor() {
@@ -16,13 +17,38 @@ export default class SavedPassages extends Component {
     }
   }
 
+  returnPassageGroupings() {
+    let representedWorks = []
+    this.state.savedPassages.forEach(el => !representedWorks.includes(el.play) ? representedWorks.push(el.play) : null)
+    const groupings = representedWorks.map(work => {
+      return this.state.savedPassages.filter(el => el.play === work).sort((a, b) => a.lineNum - b.lineNum)
+    })
+    let finalGroupings = []
+    groupings.forEach(group => {
+      let workingArray = []
+      for (var i = 0; i < group.length; i++) {
+        if (group[i + 1] && group[i + 1].lineNum - group[i].lineNum === 1) {
+          workingArray.push(group[i])
+        } else {
+          workingArray.push(group[i])
+          finalGroupings.push(workingArray)
+          workingArray = []
+        }
+      }
+    })
+    return finalGroupings
+  }
+
   compileSavedPassages() {
-    return this.state.savedPassages.map(line => {
-      let play = line.play
-      let text = line.text
-      let lineNum = line.lineNum
-      let character = line.character
-      return <PlayLine play={play} text={text} lineNum={lineNum} character={character} />
+    return this.returnPassageGroupings().map(group => {
+      return (
+        <div>
+          <h2>{group[0].fullTitle}: Act {numToRoms(group[0].act)}, scene {numToRoms(group[0].scene, true)}, lines {group[0].lineNum}-{group[group.length - 1].lineNum}</h2>
+          {group.map(line => {
+            return <PlayLine play={line.play} text={line.text} lineNum={line.lineNum} character={line.character} act={line.act} scene={line.scene} fullTitle={line.fullTitle} />
+          })}
+        </div>
+      )
     })
   }
 

--- a/src/components/SonnetText/SonnetText.js
+++ b/src/components/SonnetText/SonnetText.js
@@ -10,7 +10,7 @@ export default class SonnetText extends Component {
     }
   }
 
-  sonnetCompiler() {
+  sonnetCompiler = () => {
     const sonnet = this.formQuatrains(this.state.sonnetText.split('\\n[p]'))
     let lineKey = 0
     return sonnet.map(line => {
@@ -21,7 +21,7 @@ export default class SonnetText extends Component {
     })
   }
 
-  formQuatrains(sonnet) {
+  formQuatrains = (sonnet) => {
     let quatrain1 = sonnet.slice(0, 4)
     quatrain1.push('-')
     let quatrain2 = sonnet.slice(4, 8)
@@ -32,7 +32,7 @@ export default class SonnetText extends Component {
     return quatrain1.concat(quatrain2).concat(quatrain3).concat(couplet)
   }
 
-  render() {
+  render = () => {
     if (!this.state.isExpanded) {
       return (
         <div>

--- a/src/components/SonnetsMenu/SonnetsMenu.js
+++ b/src/components/SonnetsMenu/SonnetsMenu.js
@@ -12,7 +12,7 @@ export default class SonnetsMenu extends Component {
     }
   }
 
-  componentDidMount() {
+  componentDidMount = () => {
     fetchAllPoetry()
     .then(data => this.setState({ sonnets: data.sonnets.sort((a, b) => a.chapter - b.chapter), poems: data.poems }))
   }
@@ -27,7 +27,7 @@ export default class SonnetsMenu extends Component {
     })
   }
 
-  render() {
+  render = () => {
     return (
       <div>
         <h2>Sonnets</h2>


### PR DESCRIPTION
- This PR improves the allocation and display of line numbers across all works to facilitate localStorage. It also provides saving capability for any play.
- A hover state prompts the user to click on any line of a play to highlight it, thus saving it to localStorage.
- The new SavedPassages component accesses saved lines in localStorage and conducts a convoluted process to organize the data into lines that are immediately adjacent. Getting this to work represented a significant challenge, partly because of the way data is returned from the server. Will need refactor if time allows.
- Sonnets and Poems do not yet have the capability. This will be added in next PR.