### PR TITLE
Feature/save poetry passages

### DIFF
--- a/src/components/PoemText/PoemText.js
+++ b/src/components/PoemText/PoemText.js
@@ -1,10 +1,12 @@
 import React, { Component } from 'react'
+import PlayLine from '../PlayLine/PlayLine'
 
 export default class PoemText extends Component {
-  constructor({ fullTitle, poemText }) {
+  constructor({ poem, fullTitle, poemText }) {
     super()
     this.state = {
       isExpanded: false,
+      poem: poem,
       fullTitle: fullTitle,
       poemText: poemText
     }
@@ -12,14 +14,12 @@ export default class PoemText extends Component {
 
   poemFormatter = () => {
     return this.state.poemText.map(stanza => {
+      let lineCounter = stanza.paragraphnum - 1
       const stanzaArray = stanza.plaintext.split('\\n[p]')
       stanzaArray.push('-')
       return stanzaArray.map(line => {
-        return (
-          <div>
-            <p>{line.replace('\\n', '')}</p>
-          </div>
-        )
+        if (line !== '-') lineCounter++
+        return <PlayLine play={this.state.poem} text={line} lineNum={lineCounter} character={'shakespeare'} act={0} scene={0} fullTitle={this.state.fullTitle}/>
       })
     })
   }

--- a/src/components/SavedPassages/SavedPassages.js
+++ b/src/components/SavedPassages/SavedPassages.js
@@ -43,13 +43,27 @@ export default class SavedPassages extends Component {
     return this.returnPassageGroupings().map(group => {
       return (
         <div>
-          <h2>{group[0].fullTitle}: Act {numToRoms(group[0].act)}, scene {numToRoms(group[0].scene, true)}, lines {group[0].lineNum}-{group[group.length - 1].lineNum}</h2>
+          <h2>{this.compilePassageHeader(group[0].fullTitle, group[0].act, group[0].scene, group[0].lineNum, group[group.length - 1].lineNum)}</h2>
           {group.map(line => {
             return <PlayLine play={line.play} text={line.text} lineNum={line.lineNum} character={line.character} act={line.act} scene={line.scene} fullTitle={line.fullTitle} />
           })}
         </div>
       )
     })
+  }
+
+  compilePassageHeader(fullTitle, act, scene, firstLine, secondLine) {
+    let lines = ''
+    if (firstLine === secondLine) {
+      lines = `line ${firstLine}`
+    } else {
+      lines = `lines ${firstLine}-${secondLine}`
+    }
+    if (!act || !scene) {
+      return `${fullTitle}: ${lines}`
+    } else {
+      return `${fullTitle}: Act ${numToRoms(act)}, scene ${numToRoms(scene, true)}, ${lines}`
+    }
   }
 
   render() {

--- a/src/components/SonnetText/SonnetText.js
+++ b/src/components/SonnetText/SonnetText.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PlayLine from '../PlayLine/PlayLine'
 
 export default class SonnetText extends Component {
   constructor({ sonnetText, sonnetNumber }) {
@@ -12,12 +13,10 @@ export default class SonnetText extends Component {
 
   sonnetCompiler = () => {
     const sonnet = this.formQuatrains(this.state.sonnetText.split('\\n[p]'))
-    let lineKey = 0
+    let lineNum = 0
     return sonnet.map(line => {
-      lineKey++
-      return (
-        <p key={lineKey}>{line.replace('\\n', '')}</p>
-      )
+      if (line !== '-') lineNum ++
+      return <PlayLine play={`sonnet${this.state.number}`} text={line} lineNum={lineNum} character={'shakespeare'} act={0} scene={0} fullTitle={`Sonnet #${this.state.number}`} />
     })
   }
 

--- a/src/components/SonnetsMenu/SonnetsMenu.js
+++ b/src/components/SonnetsMenu/SonnetsMenu.js
@@ -28,16 +28,17 @@ export default class SonnetsMenu extends Component {
   }
 
   render = () => {
+    console.log(this.state)
     return (
       <div>
         <h2>Sonnets</h2>
           {this.compileSonnetDirectory()}
         <h2>Poems</h2>
-          {this.state.poems.length && <PoemText fullTitle={"Lover's Complaint"} poemText={this.state.poems.filter(poem => poem.title === 'loverscomplaint')} />}
-          {this.state.poems.length && <PoemText fullTitle={"Passionate Pilgrim"} poemText={this.state.poems.filter(poem => poem.title === 'passionatepilgrim')} />}
-          {this.state.poems.length && <PoemText fullTitle={"Phoenix and the Turtle"} poemText={this.state.poems.filter(poem => poem.title === 'phoenixturtle')} />}
-          {this.state.poems.length && <PoemText fullTitle={"Rape of Lucrece"} poemText={this.state.poems.filter(poem => poem.title === 'rapelucrece')} />}
-          {this.state.poems.length && <PoemText fullTitle={"Venus and Adonis"} poemText={this.state.poems.filter(poem => poem.title === 'venusadonis')} />}
+          {this.state.poems.length && <PoemText poem={'loverscomplaint'} fullTitle={"Lover's Complaint"} poemText={this.state.poems.filter(poem => poem.title === 'loverscomplaint')} />}
+          {this.state.poems.length && <PoemText poem={'passionatepilgrim'} fullTitle={"Passionate Pilgrim"} poemText={this.state.poems.filter(poem => poem.title === 'passionatepilgrim')} />}
+          {this.state.poems.length && <PoemText poem={'phoenixturtle'} fullTitle={"Phoenix and the Turtle"} poemText={this.state.poems.filter(poem => poem.title === 'phoenixturtle')} />}
+          {this.state.poems.length && <PoemText poem={'rapelucrece'} fullTitle={"Rape of Lucrece"} poemText={this.state.poems.filter(poem => poem.title === 'rapelucrece')} />}
+          {this.state.poems.length && <PoemText poem={'venusadonis'} fullTitle={"Venus and Adonis"} poemText={this.state.poems.filter(poem => poem.title === 'venusadonis')} />}
       </div>
     )
   }


### PR DESCRIPTION
- This PR adds line number formatting and passage-saving functionality to the Poems and Sonnets.
- The PlayLine component proved to be surprisingly reusable in both these contexts - so it should probably be renamed to just Line.
- One minor bug to note: The lines between stanzas are numbered if their preceding line number is a multiple of 5.
- Tested saving multiple passages from different genres in different orders. Overall logic seems to be formatting the saved passages correctly.
- On SavedPassages component, wrote a new method specifically devoted to compiling the saved passage header, which returns an appropriate header if the passage is from a play vs poem and if only one line was selected vs several.

Still to do:
- Testing
- Implement prop types
- Error handling
- Styling
- Pass down key props to address console errors
- Deploy app to Heroku